### PR TITLE
Add extern "C" so the library can be linked with C++ compiler and files

### DIFF
--- a/include/picovoice.h
+++ b/include/picovoice.h
@@ -17,6 +17,11 @@
 #ifndef PICOVOICE_H
 #define PICOVOICE_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**
  * Audio sample rate accepted by Picovoice.
  */
@@ -31,5 +36,9 @@ typedef enum {
     PV_STATUS_IO_ERROR,
     PV_STATUS_INVALID_ARGUMENT,
 } pv_status_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // PICOVOICE_H

--- a/include/pv_porcupine.h
+++ b/include/pv_porcupine.h
@@ -22,6 +22,11 @@
 
 #include "picovoice.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**
  * Forward declaration for keyword spotting object (a.k.a. porcupine).
  * The object detects utterances of a given keyword(s) within incoming stream of audio in real-time.
@@ -116,5 +121,9 @@ const char *pv_porcupine_version(void);
  * @return frame length.
  */
 int pv_porcupine_frame_length(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // PV_PORCUPINE_H


### PR DESCRIPTION
I had a problem where I cannot link the `libpv_porcupine.so` library with C++ code and/or compiler. It would output something like this:
```
/tmp/ccDJaGzT.o: In function `main':
demo.c:(.text+0x6c): undefined reference to `pv_porcupine_init(char const*, char const*, float, pv_porcupine_object**)'
demo.c:(.text+0xee): undefined reference to `pv_porcupine_frame_length()'
demo.c:(.text+0x12d): undefined reference to `pv_porcupine_process(pv_porcupine_object*, short const*, bool*)'
demo.c:(.text+0x132): undefined reference to `pv_porcupine_frame_length()'
demo.c:(.text+0x181): undefined reference to `pv_porcupine_delete(pv_porcupine_object*)'
```
However, I find that if I add the `extern "C"` to the header file, the error goes away. I don't really know exactly why but I thought I'd share the fix here :stuck_out_tongue: 