### PR TITLE
added non-blocking version of python demo

### DIFF
--- a/demo/python/porcupine_demo_non_blocking.py
+++ b/demo/python/porcupine_demo_non_blocking.py
@@ -1,0 +1,241 @@
+#
+# Copyright 2018 Picovoice Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import os
+import platform
+import struct
+import sys
+import time
+from datetime import datetime
+from threading import Thread
+
+import numpy as np
+import pyaudio
+import soundfile
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../binding/python'))
+
+from porcupine import Porcupine
+
+
+class PorcupineDemo(Thread):
+    """
+    Demo class for wake word detection (aka Porcupine) library. It creates an input audio stream from a microphone,
+    monitors it, and upon detecting the specified wake word(s) prints the detection time and index of wake word on
+    console. It optionally saves the recorded audio into a file for further review.
+    This is the non-blocking version that uses the callback function of PyAudio.
+    """
+
+    def __init__(
+            self,
+            library_path,
+            model_file_path,
+            keyword_file_paths,
+            sensitivity=0.5,
+            input_device_index=None,
+            output_path=None,
+            frame_length=None):
+
+        """
+        Constructor.
+
+        :param library_path: Absolute path to Porcupine's dynamic library.
+        :param model_file_path: Absolute path to the model parameter file.
+        :param keyword_file_paths: List of absolute paths to keyword files.
+        :param sensitivity: Sensitivity parameter. For more information refer to 'include/pv_porcupine.h'. It uses the
+        same sensitivity value for all keywords.
+        :param input_device_index: Optional argument. If provided, audio is recorded from this input device. Otherwise,
+        the default audio input device is used.
+        :param output_path: If provided recorded audio will be stored in this location at the end of the run.
+        :param frame_length: Used for audio buffer
+        """
+
+        super(PorcupineDemo, self).__init__()
+
+        self._library_path = library_path
+        self._model_file_path = model_file_path
+        self._keyword_file_paths = keyword_file_paths
+        self._sensitivity = float(sensitivity)
+        self.frame_length = frame_length
+        self._input_device_index = input_device_index
+
+        self._output_path = output_path
+        if self._output_path is not None:
+            self._recorded_frames = []
+
+    def run(self):
+        """
+         Creates an input audio stream, initializes wake word detection (Porcupine) object, and monitors the audio
+         stream for occurrences of the wake word(s). It prints the time of detection for each occurrence and index of
+         wake word.
+         """
+
+        num_keywords = len(self._keyword_file_paths)
+		
+        def _audio_callback(in_data, frame_count, time_info, status):
+            if frame_count >= porcupine.frame_length:
+                pcm = struct.unpack_from("h" * porcupine.frame_length, in_data)
+                result = porcupine.process(pcm)
+                if num_keywords == 1 and result:
+                    print('[%s] detected keyword' % str(datetime.now()))
+                    # add you own code execution here ... it will not block the recognition
+                elif num_keywords > 1 and result >= 0:
+                    print('[%s] detected keyword #%d' % (str(datetime.now()), result))
+                    # or add it here if you use multiple keywords
+            
+            return (None, pyaudio.paContinue)
+
+        porcupine = None
+        pa = None
+        audio_stream = None
+        try:
+            porcupine = Porcupine(
+                library_path=self._library_path,
+                model_file_path=self._model_file_path,
+                keyword_file_paths=self._keyword_file_paths,
+                sensitivities=[self._sensitivity] * num_keywords)
+
+            pa = pyaudio.PyAudio()
+            sample_rate = porcupine.sample_rate
+            num_channels = 1
+            audio_format = pyaudio.paInt16
+            if not self.frame_length:
+                frame_length = porcupine.frame_length   # if you get problems with buffer overflow you can also try: frame_length = 4096
+            else:
+                frame_length = self.frame_length
+            audio_stream = pa.open(
+                rate=sample_rate,
+                channels=num_channels,
+                format=audio_format,
+                input=True,
+                frames_per_buffer=frame_length,
+                input_device_index=self._input_device_index,
+				stream_callback=_audio_callback)
+
+            audio_stream.start_stream()
+
+            print("Started porcupine with following settings:")
+            if self._input_device_index:
+                print("Input device: %d (check with --show_audio_devices_info)" % self._input_device_index)
+            else:
+                print("Input device: default (check with --show_audio_devices_info)")
+            print("Sample-rate: %d" % sample_rate)
+            print("Channels: %d" % num_channels)
+            print("Format: %d" % audio_format)
+            print("Frame-length: %d" % frame_length)
+            print("Keyword file(s): %s" % self._keyword_file_paths)
+            print("Waiting for keywords ...\n")
+
+            while True:
+                time.sleep(0.1)
+
+        except KeyboardInterrupt:
+            print('stopping ...')
+        finally:
+            if porcupine is not None:
+                porcupine.delete()
+
+            if audio_stream is not None:
+                audio_stream.stop_stream()
+                audio_stream.close()
+
+            if pa is not None:
+                pa.terminate()
+
+            if self._output_path is not None and len(self._recorded_frames) > 0:
+                recorded_audio = np.concatenate(self._recorded_frames, axis=0).astype(np.int16)
+                soundfile.write(self._output_path, recorded_audio, samplerate=sample_rate, subtype='PCM_16')
+
+    _AUDIO_DEVICE_INFO_KEYS = ['index', 'name', 'defaultSampleRate', 'maxInputChannels']
+
+    @classmethod
+    def show_audio_devices_info(cls):
+        """ Provides information regarding different audio devices available. """
+
+        pa = pyaudio.PyAudio()
+
+        for i in range(pa.get_device_count()):
+            info = pa.get_device_info_by_index(i)
+            print(', '.join("'%s': '%s'" % (k, str(info[k])) for k in cls._AUDIO_DEVICE_INFO_KEYS))
+
+        pa.terminate()
+
+
+def _default_library_path():
+    system = platform.system()
+    machine = platform.machine()
+
+    if system == 'Darwin':
+        return os.path.join(os.path.dirname(__file__), '../../lib/mac/%s/libpv_porcupine.dylib' % machine)
+    elif system == 'Linux':
+        if machine == 'x86_64' or machine == 'i386':
+            return os.path.join(os.path.dirname(__file__), '../../lib/linux/%s/libpv_porcupine.so' % machine)
+        else:
+            raise Exception('cannot autodetect the binary type. Please enter the path to the shared object using --library_path command line argument.')
+    elif system == 'Windows':
+        if platform.architecture()[0] == '32bit':
+            return os.path.join(os.path.dirname(__file__), '..\\..\\lib\\windows\\i686\\libpv_porcupine.dll')
+        else:
+            return os.path.join(os.path.dirname(__file__), '..\\..\\lib\\windows\\amd64\\libpv_porcupine.dll')
+    raise NotImplementedError('Porcupine is not supported on %s/%s yet!' % (system, machine))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--keyword_file_paths', help='comma-separated absolute paths to keyword files', type=str)
+
+    parser.add_argument(
+        '--library_path',
+        help="absolute path to Porcupine's dynamic library",
+        type=str)
+
+    parser.add_argument(
+        '--model_file_path',
+        help='absolute path to model parameter file',
+        type=str,
+        default=os.path.join(os.path.dirname(__file__), '../../lib/common/porcupine_params.pv'))
+
+    parser.add_argument('--sensitivity', help='detection sensitivity [0, 1]', default=0.5)
+    parser.add_argument('--frame_length', help='set the frame-length manually, e.g. 4096 (experimental feature, 0=auto)', type=int, default=None)
+    parser.add_argument('--input_audio_device_index', help='index of input audio device', type=int, default=None)
+
+    parser.add_argument(
+        '--output_path',
+        help='absolute path to where recorded audio will be stored. If not set, it will be bypassed.',
+        type=str,
+        default=None)
+
+    parser.add_argument('--show_audio_devices_info', action='store_true')
+
+    args = parser.parse_args()
+
+    if args.show_audio_devices_info:
+        PorcupineDemo.show_audio_devices_info()
+    else:
+        if not args.keyword_file_paths:
+            raise ValueError('keyword file paths are missing')
+
+        PorcupineDemo(
+            library_path=args.library_path if args.library_path is not None else _default_library_path(),
+            model_file_path=args.model_file_path,
+            keyword_file_paths=[x.strip() for x in args.keyword_file_paths.split(',')],
+            sensitivity=args.sensitivity,
+            output_path=args.output_path,
+            input_device_index=args.input_audio_device_index,
+            frame_length=args.frame_length
+        ).run()

--- a/demo/python/porcupine_demo_non_blocking.py
+++ b/demo/python/porcupine_demo_non_blocking.py
@@ -47,8 +47,7 @@ class PorcupineDemo(Thread):
             keyword_file_paths,
             sensitivity=0.5,
             input_device_index=None,
-            output_path=None,
-            frame_length=None):
+            output_path=None):
 
         """
         Constructor.
@@ -61,7 +60,6 @@ class PorcupineDemo(Thread):
         :param input_device_index: Optional argument. If provided, audio is recorded from this input device. Otherwise,
         the default audio input device is used.
         :param output_path: If provided recorded audio will be stored in this location at the end of the run.
-        :param frame_length: Used for audio buffer
         """
 
         super(PorcupineDemo, self).__init__()
@@ -70,7 +68,6 @@ class PorcupineDemo(Thread):
         self._model_file_path = model_file_path
         self._keyword_file_paths = keyword_file_paths
         self._sensitivity = float(sensitivity)
-        self._frame_length = frame_length
         self._input_device_index = input_device_index
 
         self._output_path = output_path
@@ -114,10 +111,8 @@ class PorcupineDemo(Thread):
             sample_rate = porcupine.sample_rate
             num_channels = 1
             audio_format = pyaudio.paInt16
-            if self._frame_length is None:
-                frame_length = porcupine.frame_length   # if you get problems with buffer overflow you can also try: frame_length = 4096
-            else:
-                frame_length = self._frame_length
+            frame_length = porcupine.frame_length
+            
             audio_stream = pa.open(
                 rate=sample_rate,
                 channels=num_channels,
@@ -212,7 +207,6 @@ if __name__ == '__main__':
         default=os.path.join(os.path.dirname(__file__), '../../lib/common/porcupine_params.pv'))
 
     parser.add_argument('--sensitivity', help='detection sensitivity [0, 1]', default=0.5)
-    parser.add_argument('--frame_length', help='set the frame-length manually, e.g. 4096 (experimental feature, 0=auto)', type=int, default=None)
     parser.add_argument('--input_audio_device_index', help='index of input audio device', type=int, default=None)
 
     parser.add_argument(
@@ -237,6 +231,5 @@ if __name__ == '__main__':
             keyword_file_paths=[x.strip() for x in args.keyword_file_paths.split(',')],
             sensitivity=args.sensitivity,
             output_path=args.output_path,
-            input_device_index=args.input_audio_device_index,
-            frame_length=args.frame_length
+            input_device_index=args.input_audio_device_index
         ).run()


### PR DESCRIPTION
see:
https://github.com/Picovoice/Porcupine/issues/27

Starting from the input-buffer overflow issue I've encountered on my raspberry Pi zero I've changed the demo to run pyaudio in non-blocking mode (basically it does a callback to the execution function instead of waiting for processing to finish). It also gives you the chance to add some custom actions to the callback which always crashed the program in the blocking version.