### PR TITLE
Wasm init

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,48 @@ various ARM Cortex-A microprocessors and ARM Cortex-M microcontrollers is availa
 
 ## Table of Contents
 
-* [License](#license)
-* [Use Cases](#use-cases)
-* [Try It Out](#try-it-out)
-* [Performance](#performance)
-* [Model Variants](#model-variants)
-* [Structure of Repository](#structure-of-repository)
-* [Running Demo Applications](#running-demo-applications)
-    * [Python](#python-demos)
-    * [Android](#android-demos)
-    * [iOS](#ios-demos)
-    * [JavaScript](#javascript-demos)
-    * [C](#c-demos)
-* [Integration](#integration)
-    * [Python](#python)
-    * [Android](#android)
-    * [iOS](#ios)
-    * [JavaScript](#javascript)
-    * [C](#c)
-* [Releases](#releases)
-* [FAQ](#faq)
+- [Porcupine](#porcupine)
+  - [Table of Contents](#table-of-contents)
+  - [License](#license)
+  - [Use Cases](#use-cases)
+  - [Try It Out](#try-it-out)
+  - [Performance](#performance)
+  - [Model Variants](#model-variants)
+  - [Structure of Repository](#structure-of-repository)
+  - [Running Demo Applications](#running-demo-applications)
+    - [Python Demos](#python-demos)
+      - [PIP](#pip)
+      - [Repository](#repository)
+    - [Android Demos](#android-demos)
+    - [iOS Demos](#ios-demos)
+    - [JavaScript Demos](#javascript-demos)
+      - [Yarn](#yarn)
+      - [NPM](#npm)
+      - [Web Browser](#web-browser)
+    - [C Demos](#c-demos)
+  - [Integration](#integration)
+    - [Python](#python)
+      - [PIP](#pip-1)
+      - [Repository](#repository-1)
+    - [Android](#android)
+      - [Low-Level API](#low-level-api)
+      - [High-Level API](#high-level-api)
+    - [iOS](#ios)
+      - [Direct](#direct)
+      - [Binding](#binding)
+    - [JavaScript](#javascript)
+    - [C](#c)
+  - [Releases](#releases)
+    - [v1.8.0 - May 27th, 2020](#v180---may-27th-2020)
+    - [v1.7.0 - Feb 13th, 2020](#v170---feb-13th-2020)
+    - [v1.6.0 - April 25th, 2019](#v160---april-25th-2019)
+    - [v1.5.0 - November 13, 2018](#v150---november-13-2018)
+    - [v1.4.0 - July 20, 2018](#v140---july-20-2018)
+    - [v1.3.0 - June 19, 2018](#v130---june-19-2018)
+    - [v1.2.0 - April 21, 2018](#v120---april-21-2018)
+    - [v1.1.0 - April 11, 2018](#v110---april-11-2018)
+    - [v1.0.0 - March 13, 2018](#v100---march-13-2018)
+  - [FAQ](#faq)
 
 ## License
 
@@ -150,20 +172,29 @@ need an iOS device connected to your machine and a valid Apple developer account
 
 ### JavaScript Demos
 
-You need `npm` installed first. Install dependencies by executing the following commands from
-[demo/javaScript](/demo/javascript)
+You need `yarn` or `npm` installed first. Install the demo dependencies by executing either of the following sets of `yarn` or `npm` commands from
+[demo/javaScript](/demo/javascript):
+
+#### Yarn
+
+```bash
+yarn
+yarn copy
+yarn start
+```
+
+#### NPM
 
 ```bash
 npm install
 npm install -g copy-files-from-to
 copy-files-from-to
+npx serve
 ```
 
-Run this to launch the demo and follow instructions on the page.
+#### Web Browser
 
-```bash
-npx live-server --ignore="${PWD}/node_modules"
-```
+The last command will launch a local server running the demo. Open http://localhost:5000 in your web browser and follow the instructions on the page.
 
 ### C Demos
 

--- a/binding/javascript/README.md
+++ b/binding/javascript/README.md
@@ -1,11 +1,28 @@
-# Compatibility
+# JavaScript Binding for Porcupine
+
+## Compatibility
 
 The binding uses [WebAssembly](https://webassembly.org/) which is supported on
 [almost all](https://caniuse.com/#feat=wasm) modern browsers.
 
-# Usage
+## Initialization
 
-Create a new instance of engine using
+Typically, the Porcupine WASM module is loaded asynchronously, and is therefore not guaranteed to be ready the first time you wish use `Porcupine.create()`. There are two options for handling this:
+
+1. Poll the Porcupine `isLoaded()` method until it is true
+2. Supply a callback to `Porcupine` using the `PorcupineOptions` method with your function assigned to the `callback` key; it will be invoked when `isLoaded()` becomes true
+
+```javascript
+let callback = function callback() {
+  console.log("Porcupine.create() is ready to be called.");
+};
+// n.b.: PorcupineOptions must be declared before the Porcupine binding is loaded, or it will be ignored
+let PorcupineOptions = { callback: callback };
+```
+
+## Usage
+
+Create a new instance of the engine using `Porcupine.create()`:
 
 ```javascript
 let keywordModels = [new Uint8Array([...]), ...];
@@ -40,5 +57,5 @@ array can be retrieved using `handle.frameLength` and the required sample rate u
 sure to release resources acquired by WebAssembly using `.release`.
 
 ```javascript
-    handle.release();
+handle.release();
 ```

--- a/binding/javascript/porcupine.js
+++ b/binding/javascript/porcupine.js
@@ -13,14 +13,22 @@ let Porcupine = (function () {
   /**
    * Binding for wake word engine (Porcupine). It initializes the JavaScript binding for WebAssembly module and
    * exposes a factory method for creating new instances of the engine.
+   * 
+   * When the WebAssembly module has finished loading, if a callback function was provided via the PorcupineOptions object,
+   * it will be invoked. Otherwise, use `.isLoaded()` to determine if Porcupine is ready.
    */
 
-  let initWasm = null;
-  let releaseWasm = null;
-  let processWasm = null;
-  let sampleRate = null;
+  let callback = null;
   let frameLength = null;
+  let initWasm = null;
+  let processWasm = null;
+  let releaseWasm = null;
+  let sampleRate = null;
   let version = null;
+
+  if (PorcupineOptions !== undefined) {
+    callback = PorcupineOptions.callback;
+  }
 
   let porcupineModule = PorcupineModule();
   porcupineModule.then(function (Module) {
@@ -42,7 +50,10 @@ let Porcupine = (function () {
       []
     )();
     version = Module.cwrap("pv_porcupine_wasm_version", "string", [])();
-    postMessage({ type: "ppn-init" });
+
+    if (callback !== null) {
+      callback();
+    }
   });
 
   let isLoaded = function () {
@@ -50,7 +61,7 @@ let Porcupine = (function () {
      * Flag indicating if 'PorcupineModule' is loaded. '.create()' can only be called after loading is finished.
      */
 
-    return initWasm != null;
+    return initWasm !== null;
   };
 
   let create = function (keywordModels, sensitivities) {

--- a/binding/javascript/porcupine.js
+++ b/binding/javascript/porcupine.js
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018 Picovoice Inc.
+    Copyright 2018-2020 Picovoice Inc.
 
     You may not use this file except in compliance with the license. A copy of the license is located in the "LICENSE"
     file accompanying this source.
@@ -10,124 +10,158 @@
 */
 
 let Porcupine = (function () {
+  /**
+   * Binding for wake word engine (Porcupine). It initializes the JavaScript binding for WebAssembly module and
+   * exposes a factory method for creating new instances of the engine.
+   */
+
+  let initWasm = null;
+  let releaseWasm = null;
+  let processWasm = null;
+  let sampleRate = null;
+  let frameLength = null;
+  let version = null;
+
+  let porcupineModule = PorcupineModule();
+  porcupineModule.then(function (Module) {
+    initWasm = Module.cwrap("pv_porcupine_wasm_init", "number", [
+      "number",
+      "number",
+      "number",
+      "number",
+    ]);
+    releaseWasm = Module.cwrap("pv_porcupine_wasm_delete", ["number"]);
+    processWasm = Module.cwrap("pv_porcupine_wasm_process", "number", [
+      "number",
+      "number",
+    ]);
+    sampleRate = Module.cwrap("pv_wasm_sample_rate", "number", [])();
+    frameLength = Module.cwrap(
+      "pv_porcupine_wasm_frame_length",
+      "number",
+      []
+    )();
+    version = Module.cwrap("pv_porcupine_wasm_version", "string", [])();
+  });
+
+  let isLoaded = function () {
     /**
-     * Binding for wake word engine (Porcupine). It initializes the JavaScript binding for WebAssembly module and
-     * exposes a factory method for creating new instances of the engine.
+     * Flag indicating if 'PorcupineModule' is loaded. '.create()' can only be called after loading is finished.
      */
 
-    let initWasm = null;
-    let releaseWasm = null;
-    let processWasm = null;
-    let sampleRate = null;
-    let frameLength = null;
-    let version = null;
+    return initWasm != null;
+  };
 
-    let porcupineModule = PorcupineModule();
-    porcupineModule.then(function (Module) {
-        initWasm = Module.cwrap('pv_porcupine_wasm_init', 'number', ['number', 'number', 'number', 'number']);
-        releaseWasm = Module.cwrap('pv_porcupine_wasm_delete', ['number']);
-        processWasm = Module.cwrap('pv_porcupine_wasm_process', 'number', ['number', 'number']);
-        sampleRate = Module.cwrap('pv_wasm_sample_rate', 'number', [])();
-        frameLength = Module.cwrap('pv_porcupine_wasm_frame_length', 'number', [])();
-        version = Module.cwrap('pv_porcupine_wasm_version', 'string', [])();
-    });
+  let create = function (keywordModels, sensitivities) {
+    /**
+     * Creates an instance of wake word engine (Porcupine). Can be called only after '.isLoaded()' returns true.
+     * @param {Array} Array of keyword models. A keyword model is the signature for a given phrase to be detected.
+     * Each keyword model should be stored as 'UInt8Array'.
+     * @param {Float32Array} Detection sensitivities for each keywords model. A higher sensitivity reduces miss rate
+     * at the cost of potentially higher false alarm rate. Sensitivity should be a floating-point number within
+     * [0, 1].
+     * @returns An instance of the engine.
+     */
 
-    let isLoaded = function () {
-        /**
-         * Flag indicating if 'PorcupineModule' is loaded. '.create()' can only be called after loading is finished.
-         */
+    let keywordModelSizes = Int32Array.from(
+      keywordModels.map((x) => x.byteLength)
+    );
+    let keywordModelSizesPointer = porcupineModule._malloc(
+      keywordModelSizes.byteLength
+    );
+    let keywordModelSizesBuffer = new Uint8Array(
+      porcupineModule.HEAPU8.buffer,
+      keywordModelSizesPointer,
+      keywordModelSizes.byteLength
+    );
+    keywordModelSizesBuffer.set(new Uint8Array(keywordModelSizes.buffer));
 
-        return initWasm != null;
+    let keywordModelPointers = Uint32Array.from(
+      keywordModels.map((keywordModel) => {
+        let heapPointer = porcupineModule._malloc(keywordModel.byteLength);
+        let heapBuffer = new Uint8Array(
+          porcupineModule.HEAPU8.buffer,
+          heapPointer,
+          keywordModel.byteLength
+        );
+        heapBuffer.set(keywordModel);
+        return heapPointer;
+      })
+    );
+
+    let keywordModelPointersPointer = porcupineModule._malloc(
+      keywordModelPointers.byteLength
+    );
+    let keywordModelPointersBuffer = new Uint8Array(
+      porcupineModule.HEAPU8.buffer,
+      keywordModelPointersPointer,
+      keywordModelPointers.byteLength
+    );
+    keywordModelPointersBuffer.set(new Uint8Array(keywordModelPointers.buffer));
+
+    let sensitivitiesPointer = porcupineModule._malloc(
+      sensitivities.byteLength
+    );
+    let sensitivitiesBuffer = new Uint8Array(
+      porcupineModule.HEAPU8.buffer,
+      sensitivitiesPointer,
+      sensitivities.byteLength
+    );
+    sensitivitiesBuffer.set(new Uint8Array(sensitivities.buffer));
+
+    let handleWasm = initWasm(
+      keywordModels.length,
+      keywordModelSizesPointer,
+      keywordModelPointersPointer,
+      sensitivitiesPointer
+    );
+    if (handleWasm === 0) {
+      throw new Error("failed to initialize Porcupine.");
+    }
+
+    let pcmWasmPointer = porcupineModule._malloc(2 * frameLength);
+
+    let release = function () {
+      /**
+       * Releases resources acquired by WebAssembly module.
+       */
+
+      releaseWasm(handleWasm);
+      porcupineModule._free(pcmWasmPointer);
     };
 
-    let create = function (keywordModels, sensitivities) {
-        /**
-         * Creates an instance of wake word engine (Porcupine). Can be called only after '.isLoaded()' returns true.
-         * @param {Array} Array of keyword models. A keyword model is the signature for a given phrase to be detected.
-         * Each keyword model should be stored as 'UInt8Array'.
-         * @param {Float32Array} Detection sensitivities for each keywords model. A higher sensitivity reduces miss rate
-         * at the cost of potentially higher false alarm rate. Sensitivity should be a floating-point number within
-         * [0, 1].
-         * @returns An instance of the engine.
-         */
+    let process = function (pcmInt16Array) {
+      /**
+       * Processes a frame of audio. The required sample rate can be retrieved from '.sampleRate' and the length
+       * of frame (number of audio samples per frame) can be retrieved from '.frameLength'. The audio needs to be
+       * 16-bit linearly-encoded. Furthermore, the engine operates on single-channel audio.
+       * @param {Int16Array} A frame of audio with properties described above.
+       * @returns {Number} Index of detected keyword (phrase). When no keyword is detected it returns -1.
+       */
 
-        let keywordModelSizes = Int32Array.from(keywordModels.map(x => x.byteLength));
-        let keywordModelSizesPointer = porcupineModule._malloc(keywordModelSizes.byteLength);
-        let keywordModelSizesBuffer = new Uint8Array(
-            porcupineModule.HEAPU8.buffer,
-            keywordModelSizesPointer,
-            keywordModelSizes.byteLength);
-        keywordModelSizesBuffer.set(new Uint8Array(keywordModelSizes.buffer));
+      let pcmWasmBuffer = new Uint8Array(
+        porcupineModule.HEAPU8.buffer,
+        pcmWasmPointer,
+        pcmInt16Array.byteLength
+      );
+      pcmWasmBuffer.set(new Uint8Array(pcmInt16Array.buffer));
 
-        let keywordModelPointers = Uint32Array.from(keywordModels.map(keywordModel => {
-            let heapPointer = porcupineModule._malloc(keywordModel.byteLength);
-            let heapBuffer = new Uint8Array(porcupineModule.HEAPU8.buffer, heapPointer, keywordModel.byteLength);
-            heapBuffer.set(keywordModel);
-            return heapPointer;
-        }));
+      let keyword_index = processWasm(handleWasm, pcmWasmPointer);
+      if (keyword_index === -2) {
+        throw new Error("Porcupine failed to process audio");
+      }
 
-        let keywordModelPointersPointer = porcupineModule._malloc(keywordModelPointers.byteLength);
-        let keywordModelPointersBuffer = new Uint8Array(
-            porcupineModule.HEAPU8.buffer,
-            keywordModelPointersPointer,
-            keywordModelPointers.byteLength);
-        keywordModelPointersBuffer.set(new Uint8Array(keywordModelPointers.buffer));
-
-        let sensitivitiesPointer = porcupineModule._malloc(sensitivities.byteLength);
-        let sensitivitiesBuffer = new Uint8Array(
-            porcupineModule.HEAPU8.buffer,
-            sensitivitiesPointer,
-            sensitivities.byteLength);
-        sensitivitiesBuffer.set(new Uint8Array(sensitivities.buffer));
-
-        let handleWasm = initWasm(
-            keywordModels.length,
-            keywordModelSizesPointer,
-            keywordModelPointersPointer,
-            sensitivitiesPointer);
-        if (handleWasm === 0) {
-            throw new Error("failed to initialize Porcupine.");
-        }
-
-        let pcmWasmPointer = porcupineModule._malloc(2 * frameLength);
-
-        let release = function () {
-            /**
-             * Releases resources acquired by WebAssembly module.
-             */
-
-            releaseWasm(handleWasm);
-            porcupineModule._free(pcmWasmPointer);
-        };
-
-        let process = function (pcmInt16Array) {
-            /**
-             * Processes a frame of audio. The required sample rate can be retrieved from '.sampleRate' and the length
-             * of frame (number of audio samples per frame) can be retrieved from '.frameLength'. The audio needs to be
-             * 16-bit linearly-encoded. Furthermore, the engine operates on single-channel audio.
-             * @param {Int16Array} A frame of audio with properties described above.
-             * @returns {Number} Index of detected keyword (phrase). When no keyword is detected it returns -1.
-             */
-
-            let pcmWasmBuffer = new Uint8Array(porcupineModule.HEAPU8.buffer, pcmWasmPointer, pcmInt16Array.byteLength);
-            pcmWasmBuffer.set(new Uint8Array(pcmInt16Array.buffer));
-
-            let keyword_index = processWasm(handleWasm, pcmWasmPointer);
-            if (keyword_index === -2) {
-                throw new Error("Porcupine failed to process audio");
-            }
-
-            return keyword_index;
-        };
-
-        return {
-            release: release,
-            process: process,
-            sampleRate: sampleRate,
-            frameLength: frameLength,
-            version: version
-        }
+      return keyword_index;
     };
 
-    return {isLoaded: isLoaded, create: create}
+    return {
+      release: release,
+      process: process,
+      sampleRate: sampleRate,
+      frameLength: frameLength,
+      version: version,
+    };
+  };
+
+  return { isLoaded: isLoaded, create: create };
 })();

--- a/binding/javascript/porcupine.js
+++ b/binding/javascript/porcupine.js
@@ -42,6 +42,7 @@ let Porcupine = (function () {
       []
     )();
     version = Module.cwrap("pv_porcupine_wasm_version", "string", [])();
+    postMessage({ type: "ppn-init" });
   });
 
   let isLoaded = function () {

--- a/demo/javascript/index.html
+++ b/demo/javascript/index.html
@@ -2886,7 +2886,7 @@ const KEYWORDS_ID = {
         "Lime Green": "#32CD32",
         "Forest Green": "#228B22",
         "Deep Sky Blue": "#191970",
-        Magenta: "#FF00FF",
+        "Magenta": "#FF00FF",
         "White Smoke": "#F5F5F5",
         "Lavender Blush": "#FFF0F5",
         "Dim Gray": "#696969",
@@ -2969,6 +2969,7 @@ const KEYWORDS_ID = {
 
       start = function () {
         porcupineManager = PorcupineManager(
+          ready,
           "/scripts/porcupine_worker.js",
           "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js"
         );
@@ -2980,11 +2981,17 @@ const KEYWORDS_ID = {
           audioManagerErrorCallback
         );
 
-        document
-          .querySelector("#demo_button")
-          .setAttribute("onclick", "stop()");
-        document.querySelector("#demo_button").innerText = "Stop Demo";
+        let demoButton = document.querySelector("#demo_button");
+        demoButton.setAttribute("onclick", "stop()");
+        demoButton.innerText = "Initializing...";
+        demoButton.disabled = true;
       };
+
+      ready = function () {
+        let demoButton = document.querySelector("#demo_button");
+        demoButton.innerText = "Stop Demo";
+        demoButton.disabled = false;
+      }
 
       stop = function () {
         porcupineManager.stop();

--- a/demo/javascript/index.html
+++ b/demo/javascript/index.html
@@ -2951,6 +2951,12 @@ const KEYWORDS_ID = {
         }
       };
 
+      let readyCallback = function () {
+        let demoButton = document.querySelector("#demo_button");
+        demoButton.innerText = "Stop Demo";
+        demoButton.disabled = false;
+      };
+
       let porcupineManager;
 
       let audioManagerErrorCallback = function (ex) {
@@ -2968,17 +2974,14 @@ const KEYWORDS_ID = {
       };
 
       start = function () {
-        porcupineManager = PorcupineManager(
-          ready,
-          "/scripts/porcupine_worker.js",
-          "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js"
-        );
-
-        porcupineManager.start(
+        PorcupineManager.start(
           KEYWORDS_ID,
           SENSITIVITIES,
           processCallback,
-          audioManagerErrorCallback
+          audioManagerErrorCallback,
+          readyCallback,
+          "/scripts/porcupine_worker.js",
+          "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js"
         );
 
         let demoButton = document.querySelector("#demo_button");
@@ -2987,14 +2990,9 @@ const KEYWORDS_ID = {
         demoButton.disabled = true;
       };
 
-      ready = function () {
-        let demoButton = document.querySelector("#demo_button");
-        demoButton.innerText = "Stop Demo";
-        demoButton.disabled = false;
-      }
 
       stop = function () {
-        porcupineManager.stop();
+        PorcupineManager.stop();
 
         document
           .querySelector("#light_bulb")

--- a/demo/javascript/scripts/porcupine_manager.js
+++ b/demo/javascript/scripts/porcupine_manager.js
@@ -25,9 +25,9 @@ PorcupineManager = (function () {
 
     let engine = this;
 
-    // ppn-init message signals that ppn wasm has fully loaded and ready for processing
+    // ppn-init message from the worker signals that the ppn wasm has fully loaded and ready for processing
     porcupineWorker.onmessage = function (messageEvent) {
-      if (messageEvent.data.type === "ppn-init") {
+      if (messageEvent.data.status === "ppn-init") {
         porcupineWorker.postMessage({
           command: "init",
           keywordIDs: keywordIDs,

--- a/demo/javascript/scripts/porcupine_manager.js
+++ b/demo/javascript/scripts/porcupine_manager.js
@@ -9,32 +9,37 @@
     specific language governing permissions and limitations under the License.
 */
 
-PorcupineManager = (function (porcupineWorkerScript, downsamplingScript) {
-    let porcupineWorker;
+PorcupineManager = function (porcupineWorkerScript, downsamplingScript) {
+  let porcupineWorker;
 
-    let start = function (keywordIDs, sensitivities, detectionCallback, errorCallback) {
-        porcupineWorker = new Worker(porcupineWorkerScript);
-        porcupineWorker.postMessage({
-            command: "init",
-            keywordIDs: keywordIDs,
-            sensitivities: sensitivities
-        });
+  let start = function (
+    keywordIDs,
+    sensitivities,
+    detectionCallback,
+    errorCallback
+  ) {
+    porcupineWorker = new Worker(porcupineWorkerScript);
+    porcupineWorker.postMessage({
+      command: "init",
+      keywordIDs: keywordIDs,
+      sensitivities: sensitivities,
+    });
 
-        porcupineWorker.onmessage = function (e) {
-            detectionCallback(e.data.keyword);
-        };
-
-        WebVoiceProcessor.start([this], downsamplingScript, errorCallback);
+    porcupineWorker.onmessage = function (e) {
+      detectionCallback(e.data.keyword);
     };
 
-    let stop = function () {
-        WebVoiceProcessor.stop();
-        porcupineWorker.postMessage({command: "release"});
-    };
+    WebVoiceProcessor.start([this], downsamplingScript, errorCallback);
+  };
 
-    let processFrame = function (frame) {
-        porcupineWorker.postMessage({command: "process", inputFrame: frame});
-    };
+  let stop = function () {
+    WebVoiceProcessor.stop();
+    porcupineWorker.postMessage({ command: "release" });
+  };
 
-    return {start: start, processFrame: processFrame, stop: stop}
-});
+  let processFrame = function (frame) {
+    porcupineWorker.postMessage({ command: "process", inputFrame: frame });
+  };
+
+  return { start: start, processFrame: processFrame, stop: stop };
+};

--- a/demo/javascript/scripts/porcupine_manager.js
+++ b/demo/javascript/scripts/porcupine_manager.js
@@ -45,7 +45,6 @@ PorcupineManager = (function () {
   let stop = function () {
     WebVoiceProcessor.stop();
     porcupineWorker.postMessage({ command: "release" });
-    porcupineWorker.terminate();
     porcupineWorker = null;
   };
 

--- a/demo/javascript/scripts/porcupine_worker.js
+++ b/demo/javascript/scripts/porcupine_worker.js
@@ -9,6 +9,11 @@
     specific language governing permissions and limitations under the License.
 */
 
+let callback = function callback() {
+  postMessage({ status: "ppn-init" });
+};
+let PorcupineOptions = { callback: callback };
+
 importScripts("pv_porcupine.js");
 importScripts("porcupine.js");
 

--- a/demo/javascript/scripts/porcupine_worker.js
+++ b/demo/javascript/scripts/porcupine_worker.js
@@ -63,4 +63,5 @@ function release() {
   }
 
   porcupine = null;
+  close();
 }

--- a/demo/javascript/scripts/porcupine_worker.js
+++ b/demo/javascript/scripts/porcupine_worker.js
@@ -43,20 +43,15 @@ function init(keywordIDs, _sensitivities_) {
   keywordIDArray = Object.values(keywordIDs);
   keywords = Object.keys(keywordIDs);
   sensitivities = _sensitivities_;
-
-  if (Porcupine.isLoaded()) {
-    porcupine = Porcupine.create(keywordIDArray, sensitivities);
-  }
+  porcupine = Porcupine.create(keywordIDArray, sensitivities);
 }
 
 function process(inputFrame) {
-  if (porcupine === null && Porcupine.isLoaded()) {
-    porcupine = Porcupine.create(keywordIDArray, sensitivities);
-  } else if (porcupine !== null) {
-    if (!paused) {
-      let keywordIndex = porcupine.process(inputFrame);
+  if (porcupine !== null && !paused) {
+    let keywordIndex = porcupine.process(inputFrame);
+    if (keywordIndex !== -1) {
       postMessage({
-        keyword: keywordIndex === -1 ? null : keywords[keywordIndex],
+        keyword: keywords[keywordIndex],
       });
     }
   }


### PR DESCRIPTION
The porcupine JS  binding now emits a message (from its worker) to signal that the WASM has loaded and is ready to process audio frames.

The init message is also returned to the UI via a new ```readyCallback```, to allow for an intermediate "Initializing..." state to the demo button. Running the demo locally, you'd probably never notice, but if the demo was deployed remotely you might have users speaking to it before WASM was actually ready to listen.

PorcupineManager refactored to IIFE; now workers are now properly cleaned up and recycled and terminated instead of capturing the first worker and re-using it.

Formatted and cleaned up JavaScript files