### PR TITLE
implement error trait for porcupineerror

### DIFF
--- a/binding/rust/src/porcupine.rs
+++ b/binding/rust/src/porcupine.rs
@@ -177,6 +177,8 @@ impl std::fmt::Display for PorcupineError {
     }
 }
 
+impl std::error::Error for PorcupineError {}
+
 pub struct PorcupineBuilder {
     access_key: String,
     library_path: PathBuf,


### PR DESCRIPTION
This allows it to be used in a more general way, along with the `?` operator e.g.

```rust
fn main() -> Result<(), Box<dyn Error>> { todo!() }
```