### PR TITLE
Optimized the wasm memory size

### DIFF
--- a/binding/web/template/package.json
+++ b/binding/web/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "$",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Porcupine library for web browsers (via WebAssembly)",
   "author": "Picovoice Inc",
   "license": "Apache-2.0",

--- a/binding/web/template/src/porcupine.ts
+++ b/binding/web/template/src/porcupine.ts
@@ -328,7 +328,7 @@ export class Porcupine implements PorcupineEngine {
     keywordModels: ArrayLike<Uint8Array>,
     keywordModelSizes: Int32Array,
     sensitivities: Float32Array): Promise<any> {
-    const memory = new WebAssembly.Memory({ initial: 10, maximum: 300 });
+    const memory = new WebAssembly.Memory({ initial: 30, maximum: 300 });
 
     const memoryBufferUint8 = new Uint8Array(memory.buffer);
     const memoryBufferInt32 = new Int32Array(memory.buffer);

--- a/binding/web/template/src/porcupine.ts
+++ b/binding/web/template/src/porcupine.ts
@@ -328,7 +328,8 @@ export class Porcupine implements PorcupineEngine {
     keywordModels: ArrayLike<Uint8Array>,
     keywordModelSizes: Int32Array,
     sensitivities: Float32Array): Promise<any> {
-    const memory = new WebAssembly.Memory({ initial: 30, maximum: 300 });
+    // A WebAssembly page has a constant size of 64KiB. -> 6MiB ~= 100 pages
+    const memory = new WebAssembly.Memory({ initial: 100, maximum: 300 });
 
     const memoryBufferUint8 = new Uint8Array(memory.buffer);
     const memoryBufferInt32 = new Int32Array(memory.buffer);

--- a/binding/web/template/src/porcupine.ts
+++ b/binding/web/template/src/porcupine.ts
@@ -328,7 +328,7 @@ export class Porcupine implements PorcupineEngine {
     keywordModels: ArrayLike<Uint8Array>,
     keywordModelSizes: Int32Array,
     sensitivities: Float32Array): Promise<any> {
-    const memory = new WebAssembly.Memory({ initial: 1000, maximum: 2000 });
+    const memory = new WebAssembly.Memory({ initial: 10, maximum: 300 });
 
     const memoryBufferUint8 = new Uint8Array(memory.buffer);
     const memoryBufferInt32 = new Int32Array(memory.buffer);

--- a/binding/web/template/src/porcupine.ts
+++ b/binding/web/template/src/porcupine.ts
@@ -329,6 +329,7 @@ export class Porcupine implements PorcupineEngine {
     keywordModelSizes: Int32Array,
     sensitivities: Float32Array): Promise<any> {
     // A WebAssembly page has a constant size of 64KiB. -> 6MiB ~= 100 pages
+    // minimum memory requirements for init: 17 pages
     const memory = new WebAssembly.Memory({ initial: 100, maximum: 300 });
 
     const memoryBufferUint8 = new Uint8Array(memory.buffer);

--- a/binding/web/template/src/porcupine.ts
+++ b/binding/web/template/src/porcupine.ts
@@ -328,9 +328,9 @@ export class Porcupine implements PorcupineEngine {
     keywordModels: ArrayLike<Uint8Array>,
     keywordModelSizes: Int32Array,
     sensitivities: Float32Array): Promise<any> {
-    // A WebAssembly page has a constant size of 64KiB. -> 6MiB ~= 100 pages
+    // A WebAssembly page has a constant size of 64KiB. -> 8MiB ~= 128 pages
     // minimum memory requirements for init: 17 pages
-    const memory = new WebAssembly.Memory({ initial: 100, maximum: 300 });
+    const memory = new WebAssembly.Memory({ initial: 128, maximum: 512 });
 
     const memoryBufferUint8 = new Uint8Array(memory.buffer);
     const memoryBufferInt32 = new Int32Array(memory.buffer);

--- a/demo/web/index.html
+++ b/demo/web/index.html
@@ -64,7 +64,7 @@
           );
           let ppnFr = await PorcupineWebFrWorker.PorcupineWorkerFactory.create(
             accessKey,
-            [PorcupineWebEsWorker.BuiltInKeyword.Framboise],
+            [PorcupineWebFrWorker.BuiltInKeyword.Framboise],
             porcupineKeywordCallback,
             porcupineErrorCallback
           );

--- a/demo/web/package.json
+++ b/demo/web/package.json
@@ -17,10 +17,10 @@
   "author": "Picovoice Inc",
   "license": "Apache-2.0",
   "dependencies": {
-    "@picovoice/porcupine-web-de-worker": "^2.1.3",
-    "@picovoice/porcupine-web-en-worker": "^2.1.3",
-    "@picovoice/porcupine-web-es-worker": "^2.1.3",
-    "@picovoice/porcupine-web-fr-worker": "^2.1.3",
+    "@picovoice/porcupine-web-de-worker": "^2.1.4",
+    "@picovoice/porcupine-web-en-worker": "^2.1.4",
+    "@picovoice/porcupine-web-es-worker": "^2.1.4",
+    "@picovoice/porcupine-web-fr-worker": "^2.1.4",
     "@picovoice/web-voice-processor": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
found the minimum memory requirement to correctly initialize the wasm module (17 pages), observed the max memory usage (48 pages) and finally set the init memory size considering a safety margin to 100 pages (6MiB).