### PR TITLE
Migrate setup-java action to use Temurin

### DIFF
--- a/.github/workflows/java-codestyle.yml
+++ b/.github/workflows/java-codestyle.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Check Java CodeStyle
       run: java -Dconfig_loc=resources/lint/java/ -jar resources/lint/java/checkstyle-10.5.0-all.jar -c resources/lint/java/checkstyle.xml binding/android/ binding/java/ binding/flutter/android/ binding/react-native/android/ demo/android/ demo/java/

--- a/.github/workflows/java-demos.yml
+++ b/.github/workflows/java-demos.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/java-perf.yml
+++ b/.github/workflows/java-perf.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Build
       run: ./gradlew assemble

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Build
       run: ./gradlew assemble


### PR DESCRIPTION
AdoptOpenJDK has moved the the Eclipse Foundation and now distributes binaries under the new name "Eclipse Temurin"