### PR TITLE
add static to shared functions

### DIFF
--- a/binding/go/porcupine_native.go
+++ b/binding/go/porcupine_native.go
@@ -127,13 +127,13 @@ void pv_porcupine_delete_wrapper(void *f, void *object) {
 
 typedef void (*pv_set_sdk_func)(const char *);
 
-void pv_set_sdk_wrapper(void *f, const char *sdk) {
+static void pv_set_sdk_wrapper(void *f, const char *sdk) {
 	return ((pv_set_sdk_func) f)(sdk);
 }
 
 typedef int32_t (*pv_get_error_stack_func)(char ***, int32_t *);
 
-int32_t pv_get_error_stack_wrapper(
+static int32_t pv_get_error_stack_wrapper(
 	void *f,
 	char ***message_stack,
 	int32_t *message_stack_depth) {
@@ -142,7 +142,7 @@ int32_t pv_get_error_stack_wrapper(
 
 typedef void (*pv_free_error_stack_func)(char **);
 
-void pv_free_error_stack_wrapper(
+static void pv_free_error_stack_wrapper(
 	void *f,
 	char **message_stack) {
 	return ((pv_free_error_stack_func) f)(message_stack);


### PR DESCRIPTION
need to add static cause some fn's share same name as rhino, interferes while building