### PR TITLE
Change path separators in .NET build files to Windows style

### DIFF
--- a/binding/dotnet/Porcupine/Porcupine.csproj
+++ b/binding/dotnet/Porcupine/Porcupine.csproj
@@ -32,15 +32,15 @@
     <ItemGroup>
         <Content Include="Porcupine.netstandard2.0.targets">
             <PackagePath>
-                buildTransitive/netstandard2.0/Porcupine.targets;
+                buildTransitive\netstandard2.0\Porcupine.targets;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
         <Content Include="Porcupine.targets">
             <PackagePath>
-                buildTransitive/netcoreapp3.0/Porcupine.targets;
-                buildTransitive/net6.0/Porcupine.targets;
-                buildTransitive/net8.0/Porcupine.targets;
+                buildTransitive\netcoreapp3.0\Porcupine.targets;
+                buildTransitive\net6.0\Porcupine.targets;
+                buildTransitive\net8.0\Porcupine.targets;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
@@ -50,10 +50,10 @@
     <ItemGroup>
         <Content Include="..\..\..\lib\windows\amd64\libpv_porcupine.dll">
             <PackagePath>
-                buildTransitive/netstandard2.0/libpv_porcupine.dll;
-                buildTransitive/netcoreapp3.0/lib/windows/amd64/libpv_porcupine.dll;
-                buildTransitive/net6.0/lib/windows/amd64/libpv_porcupine.dll;
-                buildTransitive/net8.0/lib/windows/amd64/libpv_porcupine.dll;
+                buildTransitive\netstandard2.0\libpv_porcupine.dll;
+                buildTransitive\netcoreapp3.0\lib\windows\amd64\libpv_porcupine.dll;
+                buildTransitive\net6.0\lib\windows\amd64\libpv_porcupine.dll;
+                buildTransitive\net8.0\lib\windows\amd64\libpv_porcupine.dll;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>lib\windows\amd64\libpv_porcupine.dll</Link>
@@ -61,10 +61,10 @@
         </Content>
         <Content Include="..\..\..\lib\mac\x86_64\libpv_porcupine.dylib">
             <PackagePath>
-                buildTransitive/netstandard2.0/libpv_porcupine.dylib;
-                buildTransitive/netcoreapp3.0/lib/mac/x86_64/libpv_porcupine.dylib;
-                buildTransitive/net6.0/lib/mac/x86_64/libpv_porcupine.dylib;
-                buildTransitive/net8.0/lib/mac/x86_64/libpv_porcupine.dylib;
+                buildTransitive\netstandard2.0\libpv_porcupine.dylib;
+                buildTransitive\netcoreapp3.0\lib\mac\x86_64\libpv_porcupine.dylib;
+                buildTransitive\net6.0\lib\mac\x86_64\libpv_porcupine.dylib;
+                buildTransitive\net8.0\lib\mac\x86_64\libpv_porcupine.dylib;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>lib\mac\x86_64\libpv_porcupine.dylib</Link>
@@ -76,8 +76,8 @@
     <ItemGroup>
         <Content Include="..\..\..\lib\mac\arm64\libpv_porcupine.dylib">
             <PackagePath>
-                buildTransitive/net6.0/lib/mac/arm64/libpv_porcupine.dylib;
-                buildTransitive/net8.0/lib/mac/arm64/libpv_porcupine.dylib;
+                buildTransitive\net6.0\lib\mac\arm64\libpv_porcupine.dylib;
+                buildTransitive\net8.0\lib\mac\arm64\libpv_porcupine.dylib;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>lib\mac\arm64\libpv_porcupine.dylib</Link>
@@ -85,8 +85,8 @@
         </Content>
         <Content Include="..\..\..\lib\windows\arm64\libpv_porcupine.dll">
             <PackagePath>
-                buildTransitive/net6.0/lib/windows/arm64/libpv_porcupine.dll;
-                buildTransitive/net8.0/lib/windows/arm64/libpv_porcupine.dll;
+                buildTransitive\net6.0\lib\windows\arm64\libpv_porcupine.dll;
+                buildTransitive\net8.0\lib\windows\arm64\libpv_porcupine.dll;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>lib\windows\arm64\libpv_porcupine.dll</Link>
@@ -94,8 +94,8 @@
         </Content>
         <Content Include="..\..\..\lib\linux\x86_64\libpv_porcupine.so">
             <PackagePath>
-                buildTransitive/net6.0/lib/linux/x86_64/libpv_porcupine.so;
-                buildTransitive/net8.0/lib/linux/x86_64/libpv_porcupine.so;
+                buildTransitive\net6.0\lib\linux\x86_64\libpv_porcupine.so;
+                buildTransitive\net8.0\lib\linux\x86_64\libpv_porcupine.so;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>lib\linux\x86_64\libpv_porcupine.so</Link>
@@ -103,8 +103,8 @@
         </Content>
         <Content Include="..\..\..\lib\raspberry-pi\**\*" Exclude="..\..\..\lib\raspberry-pi\arm11\*">
             <PackagePath>
-                buildTransitive/net6.0/lib/raspberry-pi;
-                buildTransitive/net8.0/lib/raspberry-pi;
+                buildTransitive\net6.0\lib\raspberry-pi;
+                buildTransitive\net8.0\lib\raspberry-pi;
             </PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>lib\raspberry-pi\%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -130,10 +130,10 @@
                           ..\..\..\resources\keyword_files\windows\porcupine_windows.ppn;
                           ..\..\..\resources\keyword_files\windows\terminator_windows.ppn;">
             <PackagePath>
-                buildTransitive/netstandard2.0/resources/keyword_files/windows;
-                buildTransitive/netcoreapp3.0/resources/keyword_files/windows;
-                buildTransitive/net6.0/resources/keyword_files/windows;
-                buildTransitive/net8.0/resources/keyword_files/windows;
+                buildTransitive\netstandard2.0\resources\keyword_files\windows;
+                buildTransitive\netcoreapp3.0\resources\keyword_files\windows;
+                buildTransitive\net6.0\resources\keyword_files\windows;
+                buildTransitive\net8.0\resources\keyword_files\windows;
             </PackagePath>
             <Link>resources\keyword_files\windows\%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -153,10 +153,10 @@
                           ..\..\..\resources\keyword_files\mac\porcupine_mac.ppn;
                           ..\..\..\resources\keyword_files\mac\terminator_mac.ppn;">
             <PackagePath>
-                buildTransitive/netstandard2.0/resources/keyword_files/mac;
-                buildTransitive/netcoreapp3.0/resources/keyword_files/mac;
-                buildTransitive/net6.0/resources/keyword_files/mac;
-                buildTransitive/net8.0/resources/keyword_files/mac;
+                buildTransitive\netstandard2.0\resources\keyword_files\mac;
+                buildTransitive\netcoreapp3.0\resources\keyword_files\mac;
+                buildTransitive\net6.0\resources\keyword_files\mac;
+                buildTransitive\net8.0\resources\keyword_files\mac;
             </PackagePath>
             <Link>resources\keyword_files\mac\%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -176,10 +176,10 @@
                           ..\..\..\resources\keyword_files\linux\porcupine_linux.ppn;
                           ..\..\..\resources\keyword_files\linux\terminator_linux.ppn;">
             <PackagePath>
-                buildTransitive/netstandard2.0/resources/keyword_files/linux;
-                buildTransitive/netcoreapp3.0/resources/keyword_files/linux;
-                buildTransitive/net6.0/resources/keyword_files/linux;
-                buildTransitive/net8.0/resources/keyword_files/linux;
+                buildTransitive\netstandard2.0\resources\keyword_files\linux;
+                buildTransitive\netcoreapp3.0\resources\keyword_files\linux;
+                buildTransitive\net6.0\resources\keyword_files\linux;
+                buildTransitive\net8.0\resources\keyword_files\linux;
             </PackagePath>
             <Link>resources\keyword_files\linux\%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -199,17 +199,17 @@
                           ..\..\..\resources\keyword_files\raspberry-pi\porcupine_raspberry-pi.ppn;
                           ..\..\..\resources\keyword_files\raspberry-pi\terminator_raspberry-pi.ppn;">
             <PackagePath>
-                buildTransitive/netstandard2.0/resources/keyword_files/raspberry-pi;
-                buildTransitive/netcoreapp3.0/resources/keyword_files/raspberry-pi;
-                buildTransitive/net6.0/resources/keyword_files/raspberry-pi;
-                buildTransitive/net8.0/resources/keyword_files/raspberry-pi;
+                buildTransitive\netstandard2.0\resources\keyword_files\raspberry-pi;
+                buildTransitive\netcoreapp3.0\resources\keyword_files\raspberry-pi;
+                buildTransitive\net6.0\resources\keyword_files\raspberry-pi;
+                buildTransitive\net8.0\resources\keyword_files\raspberry-pi;
             </PackagePath>
             <Link>resources\keyword_files\raspberry-pi\%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
         <Content Include="..\..\..\lib\common\porcupine_params.pv">
             <PackagePath>
-                buildTransitive/common/porcupine_params.pv;
+                buildTransitive\common\porcupine_params.pv;
             </PackagePath>
             <Link>lib\common\porcupine_params.pv</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/binding/dotnet/Porcupine/Porcupine.csproj
+++ b/binding/dotnet/Porcupine/Porcupine.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net6.0;netcoreapp3.0;netstandard2.0</TargetFrameworks>
-        <Version>3.0.8</Version>
+        <Version>3.0.9</Version>
         <Authors>Picovoice</Authors>
         <Company />
         <Product>Porcupine Wake Word Engine</Product>

--- a/binding/dotnet/Porcupine/Porcupine.netstandard2.0.targets
+++ b/binding/dotnet/Porcupine/Porcupine.netstandard2.0.targets
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <Content Include="$(MSBuildThisFileDirectory)../../lib/netstandard2.0/Porcupine.dll">
+        <Content Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\Porcupine.dll">
             <Link>Porcupine.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Visible>False</Visible>
@@ -17,19 +17,19 @@
         </Content>
     </ItemGroup>
     <ItemGroup>
-        <Content Include="$(MSBuildThisFileDirectory)resources/**">
-            <Link>resources/%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Content Include="$(MSBuildThisFileDirectory)resources\**">
+            <Link>resources\%(RecursiveDir)%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-        <Content Include="$(MSBuildThisFileDirectory)lib/**">
-            <PackagePath>content/picovoice/%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
-            <Link>lib/%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <Content Include="$(MSBuildThisFileDirectory)lib\**">
+            <PackagePath>content\picovoice\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+            <Link>lib\%(RecursiveDir)%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Visible>false</Visible>
         </Content>
-        <Content Include="$(MSBuildThisFileDirectory)/../common/porcupine_params.pv">
-            <Link>lib/common/porcupine_params.pv</Link>
-            <PackagePath>content/picovoice/common/porcupine_params.pv</PackagePath>
+        <Content Include="$(MSBuildThisFileDirectory)\..\common\porcupine_params.pv">
+            <Link>lib\common\porcupine_params.pv</Link>
+            <PackagePath>content\picovoice\common\porcupine_params.pv</PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Visible>false</Visible>
         </Content>

--- a/binding/dotnet/Porcupine/Porcupine.targets
+++ b/binding/dotnet/Porcupine/Porcupine.targets
@@ -1,18 +1,18 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup>   
-        <Content Include="$(MSBuildThisFileDirectory)resources/**">
-            <Link>resources/%(RecursiveDir)%(Filename)%(Extension)</Link>
+    <ItemGroup>
+        <Content Include="$(MSBuildThisFileDirectory)resources\**">
+            <Link>resources\%(RecursiveDir)%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-        <Content Include="$(MSBuildThisFileDirectory)lib/**">
+        <Content Include="$(MSBuildThisFileDirectory)lib\**">
             <Link>lib/%(RecursiveDir)%(Filename)%(Extension)</Link>
-            <PackagePath>content/picovoice/%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+            <PackagePath>content\picovoice\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Visible>false</Visible>
         </Content>
-        <Content Include="$(MSBuildThisFileDirectory)/../common/porcupine_params.pv">
-            <Link>lib/common/porcupine_params.pv</Link>
-            <PackagePath>content/picovoice/common/porcupine_params.pv</PackagePath>
+        <Content Include="$(MSBuildThisFileDirectory)\..\common\porcupine_params.pv">
+            <Link>lib\common\porcupine_params.pv</Link>
+            <PackagePath>content\picovoice\common\porcupine_params.pv</PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Visible>false</Visible>
         </Content>

--- a/demo/dotnet/PorcupineDemo/PorcupineDemo.csproj
+++ b/demo/dotnet/PorcupineDemo/PorcupineDemo.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Porcupine" Version="3.0.8" />
+        <PackageReference Include="Porcupine" Version="3.0.9" />
         <PackageReference Include="PvRecorder" Version="1.2.10" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Seems to work okay. The slashes are converted to `/` on the platforms that prefer that by MSBuild.

Will release after approval.